### PR TITLE
Add is_array() check on _normalizeValueCraft2 to avoid possible type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.8.1 - 2018-05-04
+
+### Fixed
+
+* Fixed potential type error when moving link fields from another plugin
+
 ## 1.0.8 - 2018-04-24
 
 ### Fixed

--- a/src/fields/LinkitField.php
+++ b/src/fields/LinkitField.php
@@ -319,7 +319,7 @@ class LinkitField extends Field
             'target' => ($content['target'] ?? false) ? true : false,
         ];
 
-        if($content['type'])
+        if(is_array($content) && $content['type'])
         {
             switch ($content['type'])
             {


### PR DESCRIPTION
Hi, I started rolling this plugin out on a Craft site today to replace a few existing link plugins and ran into an issue where the `_normalizeValueCraft2` function would attempt to grab the type of existing content which was a string, this would cause 500 errors in both the control panel and on the site itself.

I've just added a quick is_array() check to that function and that seems to have done the trick!