### PR TITLE
#53 Don't use craft's project.yml for migrations.

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -46,16 +46,13 @@ class Install extends Migration
             ->all();
         foreach ($fields as $field)
         {
-            if ($field['type'] === 'FruitLinkIt')
-            {
-                $oldSettings = $field['settings'] ? Json::decode($field['settings']) : null;
-                $newSettings = $this->_migrateFieldSettings($oldSettings);
+            $oldSettings = $field['settings'] ? Json::decode($field['settings']) : null;
+            $newSettings = $this->_migrateFieldSettings($oldSettings);
 
-                $this->update('{{%fields}}', [
-                    'type' => LinkitField::class,
-                    'settings' => Json::encode($newSettings)
-                ], ['uid' => $field['uid']]);
-            }
+            $this->update('{{%fields}}', [
+                'type' => LinkitField::class,
+                'settings' => Json::encode($newSettings)
+            ], ['uid' => $field['uid']]);
         }
     }
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -29,7 +29,7 @@ class Install extends Migration
     {
         // Locate and remove old linkit
         $row = (new \craft\db\Query())
-            ->select(['id', 'settings'])
+            ->select(['id'])
             ->from(['{{%plugins}}'])
             ->where(['in', 'handle', ['fruitlinkit', 'fruit-link-it', 'fruit-linkit']])
             ->one();

--- a/src/migrations/m180423_175007_linkit_craft2.php
+++ b/src/migrations/m180423_175007_linkit_craft2.php
@@ -1,6 +1,7 @@
 <?php
 namespace fruitstudios\linkit\migrations;
 
+use fruitstudios\linkit\migrations\Install;
 use fruitstudios\linkit\Linkit;
 use fruitstudios\linkit\fields\LinkitField;
 use fruitstudios\linkit\models\Email;
@@ -24,141 +25,6 @@ class m180423_175007_linkit_craft2 extends Migration
     {
         $this->_upgradeFromCraft2();
         return true;
-    }
-
-    private function _upgradeFromCraft2()
-    {
-        // Get Project Config
-        $projectConfig = Craft::$app->getProjectConfig();
-        $projectConfig->muteEvents = true;
-
-        // Don't make the same config changes twice
-        $schemaVersion = $projectConfig->get('plugins.linkit.schemaVersion', true);
-        if ($schemaVersion && version_compare($schemaVersion, '1.0.8', '>='))
-        {
-            return;
-        }
-
-        // Locate and remove old linkit
-        $plugins = $projectConfig->get(Plugins::CONFIG_PLUGINS_KEY) ?? [];
-        foreach ($plugins as $pluginHandle => $pluginData)
-        {
-            switch ($pluginHandle)
-            {
-                case 'fruitlinkit':
-                case 'fruit-link-it':
-                case 'fruit-linkit':
-                    $projectConfig->remove(Plugins::CONFIG_PLUGINS_KEY . '.' . $pluginHandle);
-                    break;
-            }
-        }
-        $this->delete('{{%plugins}}', ['handle' => ['fruitlinkit', 'fruit-linkit', 'fruit-link-it']]);
-
-        // Get the field data from the project config
-        $fields = $projectConfig->get(Fields::CONFIG_FIELDS_KEY) ?? [];
-        foreach ($fields as $fieldUid => $field)
-        {
-            if ($field['type'] === 'FruitLinkIt')
-            {
-                $type = LinkitField::class;
-                $settings = $this->_migrateFieldSettings($field['settings']);
-
-                $field['type'] = $type;
-                $field['settings'] = $settings;
-
-                $this->update('{{%fields}}', [
-                    'type' => $type,
-                    'settings' => Json::encode($settings),
-                ], ['uid' => $fieldUid]);
-
-                $projectConfig->set(Fields::CONFIG_FIELDS_KEY . '.' . $fieldUid, $field);
-            }
-        }
-
-        $projectConfig->muteEvents = false;
-    }
-
-    private function _migrateFieldSettings($oldSettings)
-    {
-        if(!$oldSettings)
-        {
-            return null;
-        }
-
-        $linkitField = new LinkitField();
-
-        $newSettings = $linkitField->getSettings();
-        $newSettings['defaultText'] = $oldSettings['defaultText'] ?? '';
-        $newSettings['allowTarget'] = $oldSettings['allowTarget'] ?? 0;
-        $newSettings['allowCustomText'] = $oldSettings['allowCustomText'] ?? 0;
-
-        if($oldSettings['types'])
-        {
-            foreach ($oldSettings['types'] as $oldType)
-            {
-                switch ($oldType)
-                {
-                    case 'email':
-                        $newSettings['types'][Email::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                        ];
-                        break;
-
-                    case 'custom':
-                        $newSettings['types'][Url::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                        ];
-                        break;
-
-                    case 'tel':
-                        $newSettings['types'][Phone::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                        ];
-                        break;
-
-                    case 'entry':
-                        $newSettings['types'][Entry::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                            'sources' => $oldSettings['entrySources'] ?? '*',
-                            'customSelectionLabel' => $oldSettings['entrySelectionLabel'] ?? '',
-                        ];
-                        break;
-
-                    case 'category':
-                        $newSettings['types'][Category::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                            'sources' => $oldSettings['categorySources'] ?? '*',
-                            'customSelectionLabel' => $oldSettings['categorySelectionLabel'] ?? '',
-                        ];
-                        break;
-
-                    case 'asset':
-                        $newSettings['types'][Asset::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                            'sources' => $oldSettings['assetSources'] ?? '*',
-                            'customSelectionLabel' => $oldSettings['assetSelectionLabel'] ?? '',
-                        ];
-                        break;
-
-                    case 'product':
-                        $newSettings['types'][Product::class] = [
-                            'enabled' => 1,
-                            'customLabel' => null,
-                            'sources' => $oldSettings['entrySources'] ?? '*',
-                            'customSelectionLabel' => $oldSettings['entrySelectionLabel'] ?? '',
-                        ];
-                        break;
-                }
-            }
-        }
-
-        return $newSettings;
     }
 
     public function safeDown()

--- a/src/migrations/m180423_175007_linkit_craft2.php
+++ b/src/migrations/m180423_175007_linkit_craft2.php
@@ -18,7 +18,7 @@ use craft\helpers\Json;
 use craft\services\Fields;
 use craft\services\Plugins;
 
-class m180423_175007_linkit_craft2 extends Migration
+class m180423_175007_linkit_craft2 extends Install
 {
 
     public function safeUp()


### PR DESCRIPTION
Restores support for Matrix and Supertable.