### PR TITLE
Modify default label for LinkedIn social link

### DIFF
--- a/src/models/LinkedIn.php
+++ b/src/models/LinkedIn.php
@@ -24,7 +24,7 @@ class LinkedIn extends Link
 
     public static function defaultLabel(): string
     {
-        return Craft::t('linkit', 'Linked In');
+        return Craft::t('linkit', 'LinkedIn');
     }
 
     public static function defaultPlaceholder(): string


### PR DESCRIPTION
By default it is configured as "Linked In". This is incorrect for the brand name and styling. It should be "LinkedIn".