### PR TITLE
Support source array for ElementLink

### DIFF
--- a/src/base/ElementLink.php
+++ b/src/base/ElementLink.php
@@ -44,7 +44,7 @@ abstract class ElementLink extends Link implements \Stringable
     // Public
     // =========================================================================
 
-    public string $sources = '*';
+    public string|array|null $sources = '*';
     public ?string $customSelectionLabel = null;
 
     // Public Methods


### PR DESCRIPTION
Fixes a runtime error bug when trying to set an array of sources to `ElementLink::$sources`.