### PR TITLE
Fix getUrl return on elementlink

### DIFF
--- a/src/base/ElementLink.php
+++ b/src/base/ElementLink.php
@@ -68,7 +68,7 @@ abstract class ElementLink extends Link
     public function getUrl(): string
     {
         $element = $this->getElement();
-        return $element ? $element->getUrl() : '';
+        return $element ? (string) $element->getUrl() : '';
     }
 
     public function getText(): string


### PR DESCRIPTION
Entries without a url return null, which causes a 500 error.